### PR TITLE
feat: random queue image and call timer

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@
 import { initializeApp, getApps, getApp } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js";
 import {
   getFirestore, doc, setDoc, getDoc, deleteDoc,
-  collection, addDoc, onSnapshot, getDocs
+  collection, addDoc, onSnapshot, getDocs,
+  updateDoc, deleteField, arrayUnion, arrayRemove
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { 
   getAuth, signInAnonymously, onAuthStateChanged,
@@ -71,6 +72,9 @@ let callTimerInterval = null;
 let callStartTime = null;
 const queueImages = ["icons/a.jpg", "icons/garuda.png"];
 const ROOM_ID = (window.ROOM_ID || "cs-room"); // bisa di-overwrite dari HTML bila perlu
+const MAX_CALL_DURATION_SEC = 10 * 60;
+const IS_CALLER_PAGE = location.pathname.includes("caller.html");
+let wasCallerConnected = false;
 
 // =====================================================
 // ================== MODAL UTIL (CUSTOM) ==============
@@ -270,17 +274,39 @@ function inputModal({ title = "Input", placeholder = "Ketik di sini...", okText 
   });
 }
 
-function startCallTimer() {
-  callStartTime = Date.now();
-  const el = document.getElementById("callTimer");
-  if (!el) return;
-  el.style.display = "block";
-  callTimerInterval = setInterval(() => {
-    const diff = Math.floor((Date.now() - callStartTime) / 1000);
-    const m = String(Math.floor(diff / 60)).padStart(2, "0");
-    const s = String(diff % 60).padStart(2, "0");
-    el.textContent = `${m}:${s}`;
-  }, 1000);
+async function fetchOrCreateCallStartTime() {
+  const roomDocRef = doc(db, "rooms", ROOM_ID);
+  let docSnap = await getDoc(roomDocRef);
+  let start = docSnap.data()?.callStartTime;
+  if (!start) {
+    const now = Date.now();
+    await setDoc(roomDocRef, { callStartTime: now }, { merge: true });
+    docSnap = await getDoc(roomDocRef);
+    start = docSnap.data()?.callStartTime || now;
+  }
+  return start;
+}
+
+function startCallTimer(startTimeMs) {
+  if (callTimerInterval) return;
+  callStartTime = startTimeMs ?? Date.now();
+  const timerEl = document.getElementById("callTimer");
+  if (timerEl) timerEl.style.display = "block";
+  updateCallTimer();
+  callTimerInterval = setInterval(updateCallTimer, 1000);
+}
+
+function updateCallTimer() {
+  if (!callStartTime) return;
+  const elapsed = Math.floor((Date.now() - callStartTime) / 1000);
+  const remaining = MAX_CALL_DURATION_SEC - elapsed;
+  const minutes = String(Math.floor(elapsed / 60)).padStart(2, "0");
+  const seconds = String(elapsed % 60).padStart(2, "0");
+  const timerEl = document.getElementById("callTimer");
+  if (timerEl) timerEl.textContent = `${minutes}:${seconds}`;
+  if (remaining <= 0) {
+    hangUp();
+  }
 }
 
 function stopCallTimer() {
@@ -288,28 +314,149 @@ function stopCallTimer() {
     clearInterval(callTimerInterval);
     callTimerInterval = null;
   }
-  const el = document.getElementById("callTimer");
-  if (el) el.style.display = "none";
+  callStartTime = null;
+  const timerEl = document.getElementById("callTimer");
+  if (timerEl) {
+    timerEl.style.display = "none";
+    timerEl.textContent = "00:00";
+  }
+  setDoc(doc(db, "rooms", ROOM_ID), { callStartTime: deleteField() }, { merge: true }).catch(() => {});
 }
 
-function showQueueModal(pos = 1, total = 1) {
-  return new Promise((resolve) => {
-    const modal = document.getElementById("queueModal");
-    const timeEl = document.getElementById("queueTime");
-    const posEl = document.getElementById("queuePosition");
-    const totalEl = document.getElementById("queueTotal");
-    const imgEl = document.getElementById("queueImage");
-    const okBtn = document.getElementById("queueOkBtn");
-    if (!modal) { resolve(); return; }
-    timeEl.textContent = new Date().toLocaleTimeString("id-ID", { hour12: false });
-    posEl.textContent = pos;
-    totalEl.textContent = total;
-    const rand = queueImages[Math.floor(Math.random() * queueImages.length)];
-    imgEl.src = rand;
-    modal.style.display = "flex";
-    const close = () => { modal.style.display = "none"; okBtn?.removeEventListener("click", close); resolve(); };
-    okBtn?.addEventListener("click", close);
+async function addToQueue(name) {
+  const qRef = doc(db, "queues", ROOM_ID);
+  await setDoc(qRef, { list: arrayUnion(name) }, { merge: true });
+}
+
+function showWaitingModal(myName) {
+  const modal = document.getElementById("waitingModal");
+  if (!modal) return;
+  modal.style.display = "flex";
+
+  const timerEl = document.getElementById("waitTimer");
+  const posEl = document.getElementById("waitPosition");
+  const totalEl = document.getElementById("waitTotal");
+  const imgEl = document.getElementById("waitImage");
+  let startTime = null;
+  let timerInterval = null;
+  let imgInterval = null;
+  let oneMinuteWarningShown = false;
+
+  if (imgEl) {
+    const changeImage = () => {
+      const rand = queueImages[Math.floor(Math.random() * queueImages.length)];
+      imgEl.src = rand;
+    };
+    changeImage();
+    imgInterval = setInterval(changeImage, 5000);
+  }
+
+  const roomUnsub = onSnapshot(doc(db, "rooms", ROOM_ID), snap => {
+    startTime = snap.data()?.callStartTime || null;
+    if (startTime) {
+      if (!timerInterval) timerInterval = setInterval(updateTimer, 1000);
+      updateTimer();
+    } else {
+      oneMinuteWarningShown = false;
+      if (timerInterval) {
+        clearInterval(timerInterval);
+        timerInterval = null;
+      }
+      timerEl.textContent = "00:00";
+    }
   });
+
+  const queueUnsub = onSnapshot(doc(db, "queues", ROOM_ID), async snap => {
+    const data = snap.data() || {};
+    const list = data.list || [];
+    const idx = list.findIndex(n => n === myName);
+    posEl.textContent = idx >= 0 ? idx + 1 : "-";
+    totalEl.textContent = list.length;
+    if (data.allowed === myName) {
+      const ok = await showAppModal({
+        title: "Konfirmasi",
+        message: "anda dipersilahkan masuk, bersedia?",
+        okText: "Ya",
+        cancelText: "Tidak"
+      });
+      if (ok) {
+        roomUnsub();
+        queueUnsub();
+        if (timerInterval) clearInterval(timerInterval);
+        if (imgInterval) clearInterval(imgInterval);
+        modal.style.display = "none";
+        sessionStorage.setItem("calleeName", myName);
+        startCall(myName);
+      } else {
+        await updateDoc(doc(db, "queues", ROOM_ID), {
+          allowed: deleteField(),
+          list: arrayUnion(myName)
+        });
+      }
+    }
+  });
+
+  function updateTimer() {
+    if (!startTime) return;
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
+    const remaining = MAX_CALL_DURATION_SEC - elapsed;
+    const m = String(Math.floor(elapsed / 60)).padStart(2, "0");
+    const s = String(elapsed % 60).padStart(2, "0");
+    timerEl.textContent = `${m}:${s}`;
+    if (remaining <= 60 && remaining > 0 && !oneMinuteWarningShown) {
+      oneMinuteWarningShown = true;
+      alert("Panggilan akan berakhir dalam 1 menit.");
+    }
+    if (remaining <= 0) {
+      clearInterval(timerInterval);
+      timerInterval = null;
+      startTime = null;
+      oneMinuteWarningShown = false;
+      timerEl.textContent = "00:00";
+    }
+  }
+}
+
+function listenQueueForCaller() {
+  const listEl = document.getElementById("queueList");
+  if (!listEl) return;
+  const qRef = doc(db, "queues", ROOM_ID);
+  onSnapshot(qRef, (snap) => {
+    const data = snap.data() || {};
+    const list = data.list || [];
+    if (list.length) {
+      listEl.innerHTML = list
+        .map((n, i) =>
+          `<li>${i + 1}. ${formatName(n)} <button class="btn-primary allow-btn" data-name="${n}">Siap Masuk</button></li>`
+        )
+        .join("");
+      listEl.querySelectorAll(".allow-btn").forEach(btn => {
+        btn.addEventListener("click", () => allowCallee(btn.dataset.name));
+      });
+    } else {
+      listEl.innerHTML = "<li>(Kosong)</li>";
+    }
+  });
+}
+
+async function allowCallee(name) {
+  try {
+    const qRef = doc(db, "queues", ROOM_ID);
+    const snap = await getDoc(qRef);
+    const list = snap.data()?.list || [];
+    const target = name || list[0];
+    if (!target) {
+      console.warn("Tidak ada antrian.");
+      return;
+    }
+    await startCall(null, true);
+    await updateDoc(qRef, {
+      list: arrayRemove(target),
+      allowed: target,
+    });
+  } catch (e) {
+    console.warn("allowCallee error", e);
+  }
 }
 
 // ==================== INIT ====================
@@ -328,12 +475,15 @@ window.onload = async () => {
 };
 
 async function initAfterAuth() {
-  const isCallerPage = location.pathname.includes("caller.html");
   const startBtn = document.querySelector("#startCallBtn");
   const hangupBtn = document.querySelector("#hangupBtn");
 
-  if (!isCallerPage && startBtn) startBtn.remove();
+  if (!IS_CALLER_PAGE && startBtn) startBtn.remove();
   if (hangupBtn) hangupBtn.addEventListener("click", hangUp);
+
+  if (IS_CALLER_PAGE) {
+    listenQueueForCaller();
+  }
 
   // Cleanup ketika tab ditutup/refresh
   window.addEventListener("beforeunload", async () => {
@@ -348,38 +498,68 @@ async function initAfterAuth() {
 
   if (!roomSnap.exists()) {
     // Room belum dibuat oleh CS
-    if (isCallerPage && startBtn) {
+    if (IS_CALLER_PAGE && startBtn) {
       startBtn.style.display = "inline-block";
       startBtn.disabled = false;
-      startBtn.addEventListener("click", startCall);
+      startBtn.addEventListener("click", () => startCall());
     } else {
-      await alertModal("Customer Service belum memulai panggilan. Silakan coba lagi nanti.", "Belum Tersedia");
-      location.href = PAGES.thanks;
+      location.href = PAGES.busy;
+      return;
     }
   } else {
     const data = roomSnap.data();
 
-    if (isCallerPage && startBtn) {
+    if (IS_CALLER_PAGE && startBtn) {
       startBtn.style.display = "inline-block";
       startBtn.disabled = true; // room sudah ada, menunggu callee
     }
 
-    if (data?.offer && !data?.answer) {
-      // Ada offer → callee boleh join tanpa antrian
-      if (!isCallerPage) {
+    if (data?.offer && data?.answer) {
+      // Sedang melayani pelanggan lain
+      if (!IS_CALLER_PAGE) {
         const name = await showNameInputModal();
+        if (!name) { location.href = PAGES.thanks; return; }
+        sessionStorage.setItem("queueName", name);
+        const join = await showAppModal({
+          title: "Sedang Sibuk",
+          message: "Panggilan sedang berlangsung. Ingin masuk antrian?",
+          okText: "Ya",
+          cancelText: "Tidak"
+        });
+        if (join) {
+          await addToQueue(name);
+          showWaitingModal(name);
+        } else {
+          location.href = PAGES.thanks;
+        }
+      }
+    } else if (data?.offer && !data?.answer) {
+      // Ada offer → callee boleh join bila diizinkan
+      if (!IS_CALLER_PAGE) {
+        let name = new URLSearchParams(location.search).get("name") || sessionStorage.getItem("queueName");
+        if (!name) name = await showNameInputModal();
         if (!name || name.trim() === "") {
           await alertModal("Nama wajib diisi untuk bergabung ke panggilan.", "Nama Diperlukan");
           return;
         }
         sessionStorage.setItem("calleeName", name);
+        sessionStorage.setItem("queueName", name);
+        const qSnap = await getDoc(doc(db, "queues", ROOM_ID));
+        const qData = qSnap.data() || {};
+        const allowed = qData.allowed;
+        const list = qData.list || [];
+        if ((allowed && allowed !== name) || (!allowed && list.length > 0)) {
+          await addToQueue(name);
+          await alertModal("Maaf, Anda belum mendapat giliran.", "Sedang Menunggu");
+          showWaitingModal(name);
+          return;
+        }
         startCall(name).catch(async err => {
           console.error("Gagal auto-join:", err);
           await alertModal("Gagal auto-join. Silakan coba lagi.", "Kesalahan");
         });
       }
-    } else {
-      await showQueueModal(1, 1);
+    } else if (!IS_CALLER_PAGE) {
       await alertModal("Maaf, kami sedang melayani pelanggan lain saat ini.", "Sedang Sibuk");
       location.href = PAGES.busy;
     }
@@ -389,7 +569,7 @@ async function initAfterAuth() {
 }
 
 // ==================== START CALL ====================
-async function startCall(calleeNameFromInit = null) {
+async function startCall(calleeNameFromInit = null, forceCaller = false) {
   try {
     showLoading(true);
 
@@ -437,7 +617,7 @@ async function startCall(calleeNameFromInit = null) {
     localStream.getTracks().forEach(t => peerConnection.addTrack(t, localStream));
     peerConnection.ontrack = e => {
       e.streams[0].getTracks().forEach(t => remoteStream.addTrack(t));
-      if (isCaller && !callStartTime) startCallTimer();
+      fetchOrCreateCallStartTime().then(startCallTimer);
     };
 
     roomRef = doc(db, "rooms", ROOM_ID);
@@ -448,7 +628,7 @@ async function startCall(calleeNameFromInit = null) {
     // ============================================================
     monitorConnectionStatus();
 
-    if (!roomSnap.exists()) {
+    if (!roomSnap.exists() || forceCaller) {
       // ===== CALLER flow =====
       isCaller = true;
 
@@ -641,10 +821,22 @@ function monitorConnectionStatus() {
   const calleeCandidatesRef = collection(db, "rooms", ROOM_ID, "calleeCandidates");
 
   onSnapshot(callerCandidatesRef, (snapshot) => {
-    if (!isCaller) return;
-    if (!snapshot.empty) {
-      const el = document.querySelector("#currentRoom");
-      if (el) el.textContent = "Online";
+    const el = document.querySelector("#currentRoom");
+    if (isCaller) {
+      if (!snapshot.empty) {
+        if (el) el.textContent = "Online";
+      }
+    } else {
+      if (!snapshot.empty) {
+        if (el) el.textContent = "Terkoneksi";
+        if (!wasCallerConnected) {
+          fetchOrCreateCallStartTime().then(startCallTimer);
+          wasCallerConnected = true;
+        }
+      } else if (snapshot.empty && wasCallerConnected) {
+        stopCallTimer();
+        wasCallerConnected = false;
+      }
     }
   });
 
@@ -668,11 +860,12 @@ function monitorConnectionStatus() {
         });
 
         wasCalleeConnected = true;
+        fetchOrCreateCallStartTime().then(startCallTimer);
       } else if (snapshot.empty && wasCalleeConnected) {
-        showCalleeDisconnected();
         wasCalleeConnected = false;
         const label = document.getElementById("calleeNameLabel");
         if (label) label.style.display = "none";
+        hangUp(false);
       }
     } else {
       if (!snapshot.empty) {
@@ -687,7 +880,7 @@ function formatName(n) {
 }
 
 // ==================== HANG UP ====================
-async function hangUp() {
+async function hangUp(reload = true) {
   try {
     stopCallTimer();
     // ====================================================
@@ -703,7 +896,8 @@ async function hangUp() {
 
     if (isCaller) {
       await deleteRoomIfCaller();
-      location.reload();
+      await updateDoc(doc(db, "queues", ROOM_ID), { allowed: deleteField() }).catch(() => {});
+      if (reload) location.reload();
     } else {
       const roomSnap = await getDoc(doc(db, "rooms", ROOM_ID));
       await deleteCalleeCandidates();
@@ -711,7 +905,7 @@ async function hangUp() {
         location.href = PAGES.thanks;
         return;
       }
-      location.reload();
+      if (reload) location.reload();
     }
   } catch (e) {
     console.warn("hangUp error:", e);

--- a/app.js
+++ b/app.js
@@ -365,9 +365,8 @@ async function initAfterAuth() {
     }
 
     if (data?.offer && !data?.answer) {
-      // Ada offer → callee boleh join
+      // Ada offer → callee boleh join tanpa antrian
       if (!isCallerPage) {
-        await showQueueModal(1, 1);
         const name = await showNameInputModal();
         if (!name || name.trim() === "") {
           await alertModal("Nama wajib diisi untuk bergabung ke panggilan.", "Nama Diperlukan");
@@ -380,6 +379,7 @@ async function initAfterAuth() {
         });
       }
     } else {
+      await showQueueModal(1, 1);
       await alertModal("Maaf, kami sedang melayani pelanggan lain saat ini.", "Sedang Sibuk");
       location.href = PAGES.busy;
     }

--- a/app.js
+++ b/app.js
@@ -418,13 +418,24 @@ function showWaitingModal(myName) {
 }
 
 function listenQueueForCaller() {
-  const allowBtn = document.getElementById("allowBtn");
-  if (!allowBtn) return;
+  const listEl = document.getElementById("queueList");
+  if (!listEl) return;
   const qRef = doc(db, "queues", ROOM_ID);
   onSnapshot(qRef, (snap) => {
     const data = snap.data() || {};
     const list = data.list || [];
-    allowBtn.disabled = list.length === 0;
+    if (list.length) {
+      listEl.innerHTML = list
+        .map((n, i) =>
+          `<li>${i + 1}. ${formatName(n)} <button class="btn-primary allow-btn" data-name="${n}">Persilahkan</button></li>`
+        )
+        .join("");
+      listEl.querySelectorAll(".allow-btn").forEach(btn => {
+        btn.addEventListener("click", () => allowCallee(btn.dataset.name));
+      });
+    } else {
+      listEl.innerHTML = "<li>(Kosong)</li>";
+    }
   });
 }
 
@@ -472,8 +483,6 @@ async function initAfterAuth() {
 
   if (IS_CALLER_PAGE) {
     listenQueueForCaller();
-    const allowBtn = document.getElementById("allowBtn");
-    allowBtn?.addEventListener("click", () => allowCallee());
   }
 
   // Cleanup ketika tab ditutup/refresh

--- a/app.js
+++ b/app.js
@@ -418,24 +418,13 @@ function showWaitingModal(myName) {
 }
 
 function listenQueueForCaller() {
-  const listEl = document.getElementById("queueList");
-  if (!listEl) return;
+  const allowBtn = document.getElementById("allowBtn");
+  if (!allowBtn) return;
   const qRef = doc(db, "queues", ROOM_ID);
   onSnapshot(qRef, (snap) => {
     const data = snap.data() || {};
     const list = data.list || [];
-    if (list.length) {
-      listEl.innerHTML = list
-        .map((n, i) =>
-          `<li>${i + 1}. ${formatName(n)} <button class="btn-primary allow-btn" data-name="${n}">Siap Masuk</button></li>`
-        )
-        .join("");
-      listEl.querySelectorAll(".allow-btn").forEach(btn => {
-        btn.addEventListener("click", () => allowCallee(btn.dataset.name));
-      });
-    } else {
-      listEl.innerHTML = "<li>(Kosong)</li>";
-    }
+    allowBtn.disabled = list.length === 0;
   });
 }
 
@@ -483,6 +472,8 @@ async function initAfterAuth() {
 
   if (IS_CALLER_PAGE) {
     listenQueueForCaller();
+    const allowBtn = document.getElementById("allowBtn");
+    allowBtn?.addEventListener("click", () => allowCallee());
   }
 
   // Cleanup ketika tab ditutup/refresh

--- a/app.js
+++ b/app.js
@@ -896,7 +896,6 @@ async function hangUp(reload = true) {
 
     if (isCaller) {
       await deleteRoomIfCaller();
-      await updateDoc(doc(db, "queues", ROOM_ID), { allowed: deleteField() }).catch(() => {});
       if (reload) location.reload();
     } else {
       const roomSnap = await getDoc(doc(db, "rooms", ROOM_ID));
@@ -948,6 +947,14 @@ async function deleteRoomIfCaller() {
     // NOVAN-LOCK: HAPUS ROOM DOC — JANGAN UBAH
     // ====================================================
     await deleteDoc(roomRef);
+
+    try {
+      const queueRef = doc(db, "queues", ROOM_ID);
+      await setDoc(queueRef, { list: [] });
+      console.log("🧹 Queue direset");
+    } catch (e) {
+      console.warn("⚠️ Gagal reset queue:", e.message);
+    }
 
     console.log("🔥 Room & subkoleksi berhasil dihapus");
   } catch (err) {

--- a/caller.html
+++ b/caller.html
@@ -28,6 +28,7 @@
   </div>
 
   <div><span id="currentRoom"></span></div>
+  <div id="callTimer" style="display:none;">00:00</div>
 
   <div id="videos">
     <video id="localVideo" muted autoplay playsinline></video>

--- a/caller.html
+++ b/caller.html
@@ -65,6 +65,7 @@
       </div>
 
       <div class="panel-actions">
+        <button id="allowBtn" class="btn-primary" disabled>Persilahkan</button>
         <button id="closeRoomBtn" class="btn-danger">Tutup Koneksi</button>
       </div>
       <div class="note">Room & kandidat ICE akan dihapus dari Firestore.</div>

--- a/caller.html
+++ b/caller.html
@@ -64,8 +64,12 @@
         <div class="dot"></div><div class="dot"></div><div class="dot"></div>
       </div>
 
+      <div class="queue-section">
+        <h3>Daftar Antrian</h3>
+        <ul id="queueList"><li>(Kosong)</li></ul>
+      </div>
+
       <div class="panel-actions">
-        <button id="allowBtn" class="btn-primary" disabled>Persilahkan</button>
         <button id="closeRoomBtn" class="btn-danger">Tutup Koneksi</button>
       </div>
       <div class="note">Room & kandidat ICE akan dihapus dari Firestore.</div>

--- a/index.html
+++ b/index.html
@@ -58,15 +58,13 @@
     </div>
   </div>
 
-  <!-- Modal antrian dengan gambar acak -->
-  <div id="queueModal" class="modal" style="display:none;">
+  <!-- Modal menunggu antrian dengan gambar acak -->
+  <div id="waitingModal" class="modal" style="display:none;">
     <div class="modal-content">
-      <h2 id="queueTime">00:00:00</h2>
-      <p>Anda antrian <span id="queuePosition">1</span> dari <span id="queueTotal">1</span></p>
-      <img id="queueImage" src="" alt="Queue image" />
-      <div class="modal-buttons">
-        <button class="modal-button" id="queueOkBtn">OK</button>
-      </div>
+      <h2>Mohon Tunggu</h2>
+      <p>Waktu panggilan yang berlangsung: <span id="waitTimer">00:00</span></p>
+      <p>Antrian Anda: <span id="waitPosition">-</span> dari <span id="waitTotal">-</span></p>
+      <img id="waitImage" src="" alt="Queue image" />
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 
   <!-- Status -->
   <div><span id="currentRoom"></span></div>
+  <div id="callTimer" style="display:none;">00:00</div>
 
   <!-- Video -->
   <div id="videos">
@@ -62,10 +63,11 @@
   <div id="waitingModal" class="modal" style="display:none;">
     <div class="modal-content">
       <h2>Mohon Tunggu</h2>
-      <p>Waktu panggilan yang berlangsung: <span id="waitTimer">00:00</span></p>
+      <p>Waktu panggilan yang berlangsung:</p>
       <p>Antrian Anda: <span id="waitPosition">-</span> dari <span id="waitTotal">-</span></p>
       <img id="waitImage" src="" alt="Queue image" />
     </div>
+    <div id="waitTimer">00:00</div>
   </div>
 
   <!-- Script utama -->

--- a/index.html
+++ b/index.html
@@ -58,6 +58,18 @@
     </div>
   </div>
 
+  <!-- Modal antrian dengan gambar acak -->
+  <div id="queueModal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <h2 id="queueTime">00:00:00</h2>
+      <p>Anda antrian <span id="queuePosition">1</span> dari <span id="queueTotal">1</span></p>
+      <img id="queueImage" src="" alt="Queue image" />
+      <div class="modal-buttons">
+        <button class="modal-button" id="queueOkBtn">OK</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Script utama -->
   <script type="module" src="./app.js"></script>
 </body>

--- a/main.css
+++ b/main.css
@@ -118,14 +118,25 @@ body {
 
 #callTimer {
   position: fixed;
-  top: 60px;
+  bottom: 20px;
   left: 20px;
   background: rgba(0, 0, 0, 0.5);
   color: #fff;
-  padding: 8px 16px;
+  padding: 6px 12px;
   border-radius: 20px;
   font-size: 14px;
   z-index: 100;
+}
+
+#waitTimer {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 14px;
 }
 
 /* ===== NAME CALLEE STATUS ===== */
@@ -435,6 +446,11 @@ body.close-page {
   padding:10px 14px; border-radius:10px; font-weight:600; cursor:pointer;
 }
 .btn-danger:disabled{ opacity:.7; cursor:not-allowed; }
+.btn-primary{
+  background: #0ea5e9; color:#fff; border:none;
+  padding:10px 14px; border-radius:10px; font-weight:600; cursor:pointer;
+}
+.btn-primary:disabled{ opacity:.7; cursor:not-allowed; }
 .note{ font-size:12px; color: var(--panel-muted); margin-top:10px; }
 
 /* Handle/Tab untuk buka-tutup */

--- a/main.css
+++ b/main.css
@@ -116,6 +116,18 @@ body {
   z-index: 100;
 }
 
+#callTimer {
+  position: fixed;
+  top: 60px;
+  left: 20px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 14px;
+  z-index: 100;
+}
+
 /* ===== NAME CALLEE STATUS ===== */
 #calleeNameLabel {
   position: absolute;
@@ -186,6 +198,13 @@ body {
   color: white;
   outline: none;
   box-sizing: border-box;
+}
+
+#queueImage {
+  width: 80px;
+  height: auto;
+  margin: 10px auto;
+  display: block;
 }
 
 /* Buttons Container */

--- a/main.css
+++ b/main.css
@@ -201,7 +201,8 @@ body {
 }
 
 #queueImage {
-  width: 80px;
+  width: 80%;
+  max-width: 200px;
   height: auto;
   margin: 10px auto;
   display: block;

--- a/main.css
+++ b/main.css
@@ -200,7 +200,7 @@ body {
   box-sizing: border-box;
 }
 
-#queueImage {
+#waitImage {
   width: 80%;
   max-width: 200px;
   height: auto;


### PR DESCRIPTION
## Summary
- display queue modal with random image from `icons/` on callee page
- show call duration timer that starts when video connects on caller page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a957b512608329b06ffe0e0ee22751